### PR TITLE
Modify tasks to remove IP addresses from records

### DIFF
--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -4,9 +4,8 @@ dns_adblock_lists: "{{ dns_adblock_lists_defaults + dns_adblock_lists_extras }}"
 
 # Often blocklists contain these IPs. We want to remove them from our lists
 dns_replace_address:
-  - '127.0.0.1'
-  - '0.0.0.0'
-  - 'localhost'
+  - '([0-9]{1,3}\.){3}[0-9]{1,3} '  # Beware of the necessary trailing whitespace!
+  - 'localhost'                     # It is there to not match records like 1.2.3.4.domain.tld
   - '::1'
 
 dns_adblock_lists_defaults:

--- a/playbook.yml
+++ b/playbook.yml
@@ -31,7 +31,7 @@
         dest: "lists/{{ item.0 }}/{{ item.1.type }}/{{ item.1.name }}"
       loop: "{{ group_names | product(dns_adblock_lists) | list }}"
 
-    - name: Replace localhost in files
+    - name: Replace localhost and IP addresses in files
       ansible.builtin.replace:
         path: "lists/{{ item.0 }}/{{ item.1.type }}/{{ item.1.name }}"
         regexp: "{{ item.2 }}"


### PR DESCRIPTION
Fix to catch records like these: `23.77.251.5 image.mail.onedrive.com`. 