### PR TITLE
Add task to fix possible out of zone errors

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -117,6 +117,15 @@
       loop_control:
         label: "{{ item.1.name }}"
 
+    # Prevent out of zone errors caused by trailing periods
+    - name: Remove full stops at the end of lines
+      ansible.builtin.replace:
+        path: "output/{{ item.0 }}/{{ item.0 }}_{{ item.1.type }}.txt"
+        regexp: '\.$'
+      loop: "{{ group_names | product(dns_adblock_lists) | list }}"
+      loop_control:
+        label: "{{ item.1.name }}"
+
     - name: Replace whitespace with new line
       ansible.builtin.replace:
         path: "output/{{ item.0 }}/{{ item.0 }}_{{ item.1.type }}.txt"


### PR DESCRIPTION
Out of zone errors are ignored by BIND but not unbound. We need to cleanup records ending with "." to avoid issues with these zones on servers running unbound.
