### PR TITLE
Add topdomains to outputfile

### DIFF
--- a/scripts/generate_social_blocklists.sh
+++ b/scripts/generate_social_blocklists.sh
@@ -13,5 +13,9 @@ subfinder -dL generate_social_blocklists_urls --silent | \
     cat /tmp/lists/subfinder | \
     awk '{ print "0.0.0.0 " $1 }' > /tmp/lists/output
 
+grep -v -e '^#' -e '^$' generate_social_blocklists_urls | while read -r domain; do
+    echo "0.0.0.0 $domain" >> /tmp/lists/output
+done
+
 python3 generate_social_blocklists_asn.py
 cat /tmp/lists/output /tmp/AS* > /tmp/social


### PR DESCRIPTION
This will fix: https://github.com/mullvad/dns-blocklists/issues/139

subfinder sometimes only adds subdomains to the blocklist. This will ensure that the domains are added