### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We aim to update these lists on a weekly basis. You can view the latest update b
 
 # Why is list "X" not included?
 
-If you find a block list that is included it is because we have gone through these validation steps:
+If you find a block list that isn't included it is because we have gone through these validation steps:
 - The blocklist is an amalgamation of other blocklists.
 - The blocklist no longer maintained.
 - The blocklist blocks things we do not believe should be blocked (like our own domains).


### PR DESCRIPTION
Changed wording of "If you find a block list that is included it is because we have gone through these validation steps:" to say "isn't included" rather than "is included", under the "Why is list "X" not included?" header.

The way it reads currently contradicts the list that follows it, as the validation steps you take to INCLUDE a blocklist would ideally not result in a blocklist that "blocks things we do not believe should be blocked (like our own domains)."

However, the sentence in question should probably be further restructured for clarity, as it is likely not the case that any and all un-included blocklists they find have already been validated.

If I am missing something, please disregard this update.