### PR TITLE
Update README.md.j2 - Why Lists are not included

### DIFF
--- a/templates/README.md.j2
+++ b/templates/README.md.j2
@@ -8,9 +8,9 @@ We aim to update these lists on a weekly basis. You can view the latest update b
 
 # Why is list "X" not included?
 
-If you find a block list that is included it is because we have gone through these validation steps:
+If you find a block list is excluded it is because we have gone through these validation steps:
 - The blocklist is an amalgamation of other blocklists.
-- The blocklist no longer maintained.
+- The blocklist is no longer maintained.
 - The blocklist blocks things we do not believe should be blocked (like our own domains).
 
 We periodically make exceptions to the included URLs for the following reasons:


### PR DESCRIPTION
blocklist exclusion readme wording seems off.
"excluded" could maybe instead be "not included" though, since the repository doesn't explicitly exclude lists it simply includes desired ones.