### PR TITLE
Add support for AdGuardTeam filters, add Mobilefilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ We currently use these advertising blocklists with our service:
 - AdguardDNS: https://v.firebog.net/hosts/AdguardDNS.txt
 - hagezi-popupads-onlydomains: https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/wildcard/popupads.txt
 - mullvad-ads-blocklist: custom file
+- adguard-filters-mobile: https://adguardteam.github.io/AdguardFilters/MobileFilter/sections/adservers.txt
 
 ### Adult content 
 

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -58,6 +58,10 @@ dns_blocklists_lists:
     type: adblock
     content: "{{ lookup('ansible.builtin.file', 'files/adblock') }}"
 
+  - name: adguard-filters-mobile
+    type: adblock
+    url: https://adguardteam.github.io/AdguardFilters/MobileFilter/sections/adservers.txt
+
   - name: oisd-nsfw
     url: https://nsfw.oisd.nl/rpz
     type: adult

--- a/playbook.yml
+++ b/playbook.yml
@@ -141,12 +141,33 @@
               - "$"
               - "@"
               - '\$TTL'
+              - '!'
+              - '/'
+              - ':'
 
         - name: Replace comments with ' ' from all lines
           ansible.builtin.replace:
             path: "{{ item.path }}"
             regexp: '#.*$'
             replace: ''
+          loop: "{{ _find_lists.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+
+        - name: Replace || and ^ with ''
+          ansible.builtin.replace:
+            path: "{{ item.path }}"
+            regexp: '(^\|\|)|(\$.*)|(\^.*)'
+            replace: ''
+          loop: "{{ _find_lists.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+
+        - name: Remove lines with *. in the middle, and /.* at the end of a URL
+          ansible.builtin.lineinfile:
+            path: "{{ item.path }}"
+            regexp: '(.\*.*)|(\/.*)'
+            state: absent
           loop: "{{ _find_lists.files }}"
           loop_control:
             label: "{{ item.path }}"


### PR DESCRIPTION
This PR aims to add support for newer blocklists, those with different layouts.

AdGuardTeam's blocklists include || and ^, which has meant we need to filter them out a bit.

The intention is to trial whether this is useful, it might be the case that we wish to remove this later on.